### PR TITLE
Fix erroneous falsy reply when requiring all roles

### DIFF
--- a/lib/authorization.js
+++ b/lib/authorization.js
@@ -74,8 +74,8 @@ module.exports = {
       }
       const intersection = _.intersection(allowed, actual)
       debug('intersection: %j', intersection)
-      if (combinedOptions.all && intersection.length !== allowed.length) {
-        return false
+      if (combinedOptions.all) {
+        return (intersection.length === allowed.length)
       }
       return (combinedOptions.any && intersection.length > 0)
     })


### PR DESCRIPTION
This fixes a simple bug that would cause authorization to always fail if `combinedOptions.all` was true. The expected behavior when this option is set is to verify that the size of the intersection exactly matches that of the allowed roles such that the user must have all of the supplied roles to be authorized.